### PR TITLE
docs: fix refactor description in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 | `fix` | Bug fix |
 | `docs` | Documentation only |
 | `style` | Code style (formatting, etc.) |
-| `refactor` | Code refactoring |
+| `refactor` | Code refactoring without changing behavior |
 | `test` | Adding or fixing tests |
 | `chore` | Maintenance tasks |
 


### PR DESCRIPTION
Fixed the description for 'refactor' commit type to be more descriptive: 'Code refactoring without changing behavior'