### PR TITLE
fix(paths): preserve relative paths in ensure_output_dir output (#10)

### DIFF
--- a/src/anyformat/utils/paths.py
+++ b/src/anyformat/utils/paths.py
@@ -14,14 +14,31 @@ def ensure_output_dir(output_path: str) -> Path:
     - Windows: C:\\Users\\... or \\\\server\\share\\...
     - Unix: /home/user/...
     - Relative paths on all platforms
+
+    Returns:
+        If `output_path` is relative, the returned Path is also relative to
+        the current working directory (so that `monkeypatch.chdir` in tests
+        works as expected on macOS where /var is a symlink to /private/var).
+        If `output_path` is absolute, an absolute Path is returned.
     """
     path = Path(output_path)
+    is_relative = not path.is_absolute()
 
-    if not path.is_absolute():
-        path = Path.cwd() / path
+    if is_relative:
+        absolute_path = Path.cwd() / path
+    else:
+        absolute_path = path
 
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    absolute_path.mkdir(parents=True, exist_ok=True)
+
+    if is_relative:
+        try:
+            return absolute_path.relative_to(Path.cwd())
+        except ValueError:
+            # Fallback if path is on a different drive (Windows) or otherwise
+            # not expressible relative to CWD — return absolute as before.
+            return absolute_path
+    return absolute_path
 
 
 def normalize_path(path: str) -> str:


### PR DESCRIPTION
## Summary

Closes #10 — `ensure_output_dir()` now preserves the relativity of its input. If you pass in a relative path, you get a relative path back. If you pass in an absolute path, you get an absolute path back.

## Root cause

```python
def ensure_output_dir(output_path: str) -> Path:
    path = Path(output_path)
    if not path.is_absolute():
        path = Path.cwd() / path   # <-- always converts to absolute
    path.mkdir(parents=True, exist_ok=True)
    return path
```

The function converted relative input to an absolute path internally, then returned that absolute path. On macOS this breaks tests that use `monkeypatch.chdir` because the system resolves `/var` through a symlink to `/private/var`, so a path computed via `Path.cwd() / "out"` may end up on a different physical location than the test's expected `Path("out")`.

## What's changed

**`src/anyformat/utils/paths.py`:**
- Track whether the input was relative (`is_relative = not path.is_absolute()`)
- Compute the absolute target path for `mkdir` (must be absolute to create the dir)
- After `mkdir`, if input was relative, return `absolute_path.relative_to(Path.cwd())`
- If `relative_to` raises `ValueError` (e.g. different drive on Windows), fall back to absolute — same behavior as before, no regression

## Test

The failing test `test_ensure_output_dir_relative_path` should now pass:

```python
def test_ensure_output_dir_relative_path(tmp_path, monkeypatch):
    monkeypatch.chdir(tmp_path)
    result = ensure_output_dir("output")
    assert result == Path("output")   # now works
```

Existing absolute-path tests are unaffected.

**Closes** #10